### PR TITLE
Ignore EXIF exceptions

### DIFF
--- a/sorl/thumbnail/engines/pil_engine.py
+++ b/sorl/thumbnail/engines/pil_engine.py
@@ -27,7 +27,7 @@ class Engine(EngineBase):
     def _orientation(self, image):
         try:
             exif = image._getexif()
-        except AttributeError:
+        except (AttributeError, IOError, KeyError, IndexError):
             exif = None
         if exif:
             orientation = exif.get(0x0112)


### PR DESCRIPTION
Backporting a bug fix from the official Sorl Thumbnail library, to this custom version.

The modification I am backporting was made in this commit:
https://github.com/mariocesar/sorl-thumbnail/commit/66a371d14a51526df7cbcef9cc61823f265a44b8
Line 58

Discussed in issue 98:
https://github.com/mariocesar/sorl-thumbnail/issues/98
