### PR TITLE
Use json from stdlib instead of simplejson

### DIFF
--- a/sorl/thumbnail/helpers.py
+++ b/sorl/thumbnail/helpers.py
@@ -1,15 +1,15 @@
 import hashlib
+import json
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.encoding import smart_str
 from django.utils.importlib import import_module
-from django.utils import simplejson
 
 
 class ThumbnailError(Exception):
     pass
 
 
-class SortedJSONEncoder(simplejson.JSONEncoder):
+class SortedJSONEncoder(json.JSONEncoder):
     """
     A json encoder that sorts the dict keys
     """
@@ -37,11 +37,11 @@ def tokey(*args):
 
 
 def serialize(obj):
-    return simplejson.dumps(obj, cls=SortedJSONEncoder)
+    return json.dumps(obj, cls=SortedJSONEncoder)
 
 
 def deserialize(s):
-    return simplejson.loads(s)
+    return json.loads(s)
 
 
 def get_module_class(class_path):

--- a/sorl/thumbnail/images.py
+++ b/sorl/thumbnail/images.py
@@ -1,3 +1,4 @@
+import json
 import re
 import urllib2
 from django.core.files.base import File, ContentFile
@@ -5,7 +6,6 @@ from django.core.files.storage import Storage, default_storage
 from django.core.urlresolvers import reverse
 from django.utils.encoding import force_unicode
 from django.utils.functional import LazyObject
-from django.utils import simplejson
 from sorl.thumbnail.conf import settings
 from sorl.thumbnail.helpers import ThumbnailError, tokey, get_module_class
 from sorl.thumbnail import default
@@ -24,11 +24,11 @@ def serialize_image_file(image_file):
         'storage': image_file.serialize_storage(),
         'size': image_file.size,
     }
-    return simplejson.dumps(data)
+    return json.dumps(data)
 
 
 def deserialize_image_file(s):
-    data = simplejson.loads(s)
+    data = json.loads(s)
     class LazyStorage(LazyObject):
         def _setup(self):
             self._wrapped = get_module_class(data['storage'])()


### PR DESCRIPTION
This PR updates the code to use json from the standard library, instead of the deprecated simplejson from django contrib.
